### PR TITLE
PARTITION_STYLE="msdos" broken on storage with 4k blocks

### DIFF
--- a/common.sh.in
+++ b/common.sh.in
@@ -101,9 +101,9 @@ format_disk0() {
   if sfdisk --help | fgrep -q -- '--no-reread'; then
     ARGS="--no-reread $ARGS"
   fi
-
+  ARGS="--label dos $ARGS"
   sfdisk $ARGS --quiet "$1" <<EOF
-${PARTITION_ALIGNMENT},,L,*
+1M,,L,*
 EOF
 }
 
@@ -127,6 +127,18 @@ map_disk0() {
 
 unmap_disk0() {
   kpartx -d -p- $1
+
+  if sfdisk --help | fgrep -q -- '--no-reread'; then
+    ARGS="--no-reread $ARGS"
+  fi
+
+  # loopback device has correct 512b blocks
+  blockdev=$(losetup --show -f $1)
+  sfdisk $ARGS --delete "$blockdev"
+  sfdisk $ARGS --label dos --quiet $blockdev <<EOF
+2048,,L,*
+EOF
+  losetup -d $blockdev
 }
 
 cleanup() {
@@ -161,7 +173,6 @@ fi
 : ${VARIANTS_DIR:="@sysconfdir@/ganeti/instance-debootstrap/variants"}
 : ${GENERATE_CACHE:="yes"}
 : ${CLEAN_CACHE:="14"} # number of days to keep a cache file
-: ${PARTITION_ALIGNMENT:=2048} # sectors to align partition (1Mib default)
 if [ -z "$OS_API_VERSION" -o "$OS_API_VERSION" = "5" ]; then
   DEFAULT_PARTITION_STYLE="none"
 else

--- a/defaults
+++ b/defaults
@@ -74,9 +74,3 @@ CLEAN_CACHE="14"
 # Ganeti 1.2 (os api version 5)
 # PARTITION_STYLE="none"
 
-# PARTITION_ALIGNMENT: the alignment of the partitions in sectors
-# (512B); this defaults to 1MiB to give grub enough space for
-# embedding and for better alignment with modern media (HDDs and
-# SSDs), feel free to increase it if your media has even bigger
-# allocation blocks
-# PARTITION_ALIGNMENT=2048


### PR DESCRIPTION
debootstrap on nodes with 4k storage blocks will create invalid partition table which won't boot inside kvm since it expects partition table with 512b blocks.

PARTITION_ALIGNMENT is currently broken and I opted to remove it all together because with 4k blocks it has VERY different behavior if you are using 2048 or 1M as argument. Since this is triggered only when PARTITION_STYLE="msdos" is used, and 1Mb os enough space i decided to hard-code that.

I'm open to suggestions how to fix this better or in cleaner way.

First commit is change which comes from Debian and is required for recent sfdisk versions, I don't know why this repository doesn't have it. It comes from https://sources.debian.org/patches/ganeti-instance-debootstrap/0.16-2.1/