### PR TITLE
Description: Skip newer sfdisk's check using the BLKRRPART ioctl

### DIFF
--- a/common.sh.in
+++ b/common.sh.in
@@ -89,11 +89,19 @@ get_api10_arguments() {
 format_disk0() {
   # Create one big partition, and make it bootable.
   local ARGS
+
   # Some versions of sfdisk need manual specification of head/sectors
   # for devices such as drbd which don't report geometry.
   if sfdisk --help | grep -q -e '--cylinders'; then
     ARGS="-H 64 -S 32 -u S --Linux"
   fi
+
+  # Some versions of sfdisk need to be told to skip checking using ioctl(dev,
+  # BLKRRPART), as this always fails for DRBD and LVM devices.
+  if sfdisk --help | fgrep -q -- '--no-reread'; then
+    ARGS="--no-reread $ARGS"
+  fi
+
   sfdisk $ARGS --quiet "$1" <<EOF
 ${PARTITION_ALIGNMENT},,L,*
 EOF


### PR DESCRIPTION
Newer sfdisk versions (>= 2.26) issue a BLKRRPART ioctl to check if a device
is in use prior to partitioning it. However, the BLKRRPART ioctl may fail for
a number of other reasons, including when a device is allocated as
non-partitionable using alloc_disk(1). Since DRBD and LVM devices are
allocated as non-partionable, sfdisk will always think they're busy and fail.

Since we're dealing with DRBD and LVM devices mostly, we need to work our way
around this and pass `--no-reread` if sfdisk supports it.