### PR TITLE
respect Linux capabilities(7) in cache (proxy PR)

### DIFF
--- a/create
+++ b/create
@@ -83,7 +83,7 @@ if [ "$CLEAN_CACHE" -a -d "$CACHE_DIR" ]; then
 fi
 
 if [ -f "$CACHE_FILE" ]; then
-  tar xf "$CACHE_FILE" -C $TMPDIR
+  tar --acls --selinux --xattrs --xattrs-include='*' -x -f "$CACHE_FILE" -C $TMPDIR
 else
   if [ "$PROXY" ]; then
     export http_proxy="$PROXY"
@@ -109,7 +109,7 @@ else
 
   if [ "$GENERATE_CACHE" = "yes" ]; then
     TMP_CACHE=`mktemp "${CACHE_FILE}.XXXXXX"`
-    tar cf "$TMP_CACHE" -C $TMPDIR .
+    tar --acls --selinux --xattrs --xattrs-include='*' -c -f "$TMP_CACHE" -C $TMPDIR .
     mv -f "$TMP_CACHE" "$CACHE_FILE"
   fi
 fi


### PR DESCRIPTION
The default GNU tar configuration does not carry fancy extended
attributes and that is where, among other things, stuff like Linux
capabilities(7) are stored. This is kind of important because that's
how ping(8) works for regular users.

We shove --selinux and --acls in there while we're at it, because why
not. We never know what the future might bring, and it seems
silly *not* to create a complete archive.

Note that --xattrs-include='*' is important because, by default, GNU
tar will not include capabilities /even/ if --xattrs is specified on
the commandline, see this bug report for details:

https://bugzilla.redhat.com/show_bug.cgi?id=771927

original author: Antoine Beaupré <anarcat@debian.org>