### PR TITLE
inform about the correct minimum disk size

### DIFF
--- a/create
+++ b/create
@@ -44,7 +44,7 @@ fi
 DEVICE_SIZE=$(blockdev --getsize64 $blockdev)
 if [ "$DEVICE_SIZE" -lt $MIN_DEV_SIZE ]; then
   echo "Device size is too small ($((DEVICE_SIZE/1048576)) MB)" 1>&2
-  echo "Required size is at least 256MB" 1>&2
+  echo "Required size is at least 512MB" 1>&2
   exit 1
 fi
 


### PR DESCRIPTION
The minimum disk size is intended to be 512MB. $MIN_DEV_SIZE is set
to 1MB smaller, to account for potential rounding. The test correctly
compares, if the instance disk is >=511MB. However the log message
still refers to an older value of 256MB. This commit fixes the log
message to the intended 512MB.