### PR TITLE
updated timezone script which uses localtime

### DIFF
--- a/examples/hooks/timezone
+++ b/examples/hooks/timezone
@@ -4,9 +4,10 @@
 # or to the one of the host is none is configured.
 
 if [ -r confdata/timezone ]; then
-  cp confdata/timezone $TARGET/etc/
+  TZ=`cat "confdata/timezone"`
 else
-  cp /etc/timezone $TARGET/etc/
+  TZ=`cat "/etc/timezone"`
 fi
 
+chroot $TARGET ln -sf /usr/share/zoneinfo/${TZ} /etc/localtime
 chroot $TARGET dpkg-reconfigure --frontend noninteractive tzdata


### PR DESCRIPTION
This version uses /etc/localtime rather than /etc/timezone, because the latter gets overwritten by reconfigure tzdata when being used in the old script.