### PR TITLE
remap the partitions after creating the filesystem

### DIFF
--- a/create
+++ b/create
@@ -61,6 +61,13 @@ else
 fi
 
 mke2fs -Fjqt $OSP_FILESYSTEM $filesystem_dev
+
+# in some cases, mkfs will remap the partition tables, for example
+# /dev/mapper/foo-1 will turn into /dev/mapper/foo-part1. Rebuild the
+# map so we correct that:
+unmap_disk0 $blockdev
+filesystem_dev=$(map_disk0 $blockdev)
+
 root_uuid=$($VOL_ID $filesystem_dev )
 
 if [ -n "$swapdev" ]; then


### PR DESCRIPTION
It's unclear to me why, but sometimes `mkfs` remaps the partitions and
then `blkid` cannot find them anymore.

The fun thing is that the entire script will just silently fail in
this case, because the `$VOL_ID` line will fail without an error, and
the rollback will just cleanup everything.

I had to add a lot of debugging in the script to figure out exactly
what was going on.

Not sure at all this is the right solution, but hopefully...

Closes: #13