### PR TITLE
move away from /etc/timezone

### DIFF
--- a/examples/hooks/timezone
+++ b/examples/hooks/timezone
@@ -6,7 +6,7 @@
 if [ -r confdata/timezone ]; then
   TZ=`cat "confdata/timezone"`
 else
-  TZ=`cat "/etc/timezone"`
+  TZ=`realpath --relative-to /usr/share/zoneinfo /etc/localtime`
 fi
 
 chroot $TARGET ln -sf /usr/share/zoneinfo/${TZ} /etc/localtime


### PR DESCRIPTION
/etc/timezone is Debian specific and obsolete[1]. Use /etc/localtime only.

[1] https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1038839