### PR TITLE
Fix case where ifupdown isn't installed

### DIFF
--- a/create
+++ b/create
@@ -135,7 +135,8 @@ EOF
 UUID=$swap_uuid   swap            swap    defaults        0       0
 EOF
 
-cat > $TMPDIR/etc/network/interfaces <<EOF
+# Only create an interfaces file if the `ifupdown` package /etc/network directory exists.
+[ -d "${TMPDIR}/etc/network" ] && cat > "${TMPDIR}/etc/network/interfaces" <<EOF
 auto lo
 iface lo inet loopback
 EOF


### PR DESCRIPTION
Ubuntu uses `netplan.io` rather than `ifupdown` to manage network interfaces. Don't try and touch the `/etc/network/interfaces` file unless the directory is created first.

Fixes: https://github.com/ganeti/instance-debootstrap/issues/23